### PR TITLE
Add ChatGPT conversation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-README.md
+# Playground
+
+This repository contains sample scripts.
+
+## chatbots.py
+
+`chatbots.py` uses the OpenAI API to simulate two ChatGPT bots that talk to each other about a user-provided topic.
+
+### Requirements
+
+- Python 3.8+
+- `openai` Python package
+- An OpenAI API key set in the `OPENAI_API_KEY` environment variable
+
+### Usage
+
+```bash
+python chatbots.py "<topic>" --turns 3
+```
+
+The script will alternate messages between Bot A and Bot B for the specified number of turns.
+

--- a/chatbots.py
+++ b/chatbots.py
@@ -1,0 +1,40 @@
+import argparse
+import os
+import openai
+
+
+def chat_with_bot(system_prompt, conversation):
+    messages = [{"role": "system", "content": system_prompt}] + conversation
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=messages
+    )
+    return response['choices'][0]['message']['content'].strip()
+
+
+def run_conversation(topic, turns=5):
+    bot_a_prompt = "You are ChatGPT Bot A."
+    bot_b_prompt = "You are ChatGPT Bot B."
+    conversation = [{"role": "user", "content": f"Let's talk about {topic}."}]
+
+    for _ in range(turns):
+        reply_a = chat_with_bot(bot_a_prompt, conversation)
+        print(f"Bot A: {reply_a}")
+        conversation.append({"role": "assistant", "content": reply_a})
+
+        reply_b = chat_with_bot(bot_b_prompt, conversation)
+        print(f"Bot B: {reply_b}")
+        conversation.append({"role": "assistant", "content": reply_b})
+
+
+if __name__ == "__main__":
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    if not openai.api_key:
+        raise SystemExit("Please set OPENAI_API_KEY environment variable.")
+
+    parser = argparse.ArgumentParser(description="Two ChatGPT bots conversation")
+    parser.add_argument("topic", help="Topic for the conversation")
+    parser.add_argument("--turns", type=int, default=5, help="Number of exchanges")
+    args = parser.parse_args()
+
+    run_conversation(args.topic, args.turns)


### PR DESCRIPTION
## Summary
- add Python script to simulate two ChatGPT bots conversing
- document usage in README

## Testing
- `python -m py_compile chatbots.py`


------
https://chatgpt.com/codex/tasks/task_e_68548f90a5b8833398f90c84eaa3e1c2