### PR TITLE
Add personality-based rot configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ The script will alternate messages between Bot A and Bot B for the specified num
 ### Usage
 
 ```bash
-python memory_chatbots.py "<topic>" --turns 3
+python memory_chatbots.py "<topic>" --turns 3 --personality excited
 ```
 
-The bots will read the current summary before replying so they retain a minimal context.
+The `--personality` flag selects a preset style and also controls how many words
+are retained in the running summary (the "rot" value). Use `--help` to see
+available personalities.
 

--- a/memory_chatbots.py
+++ b/memory_chatbots.py
@@ -1,9 +1,10 @@
 class ConversationState:
     """Keeps the conversation log and running summary in memory."""
 
-    def __init__(self):
+    def __init__(self, rot=30):
         self.messages = []  # list of {"role": str, "content": str}
         self.summary = ""
+        self.rot = rot
 
     def append(self, role, content):
         self.messages.append({"role": role, "content": content})
@@ -13,33 +14,47 @@ class ConversationState:
         """Create a very small summary from the last few messages."""
         last_msgs = [m["content"] for m in self.messages[-3:]]
         text = " ".join(last_msgs)
-        # keep at most 30 words in the summary
+        # keep at most ``rot`` words in the summary
         words = text.split()
-        if len(words) > 30:
-            words = words[-30:]
+        if len(words) > self.rot:
+            words = words[-self.rot:]
         self.summary = " ".join(words)
 
     def get_summary(self):
         return self.summary
 
 
-def bot_response(bot_name, topic, summary):
-    """Return a simple bot response referencing the latest summary."""
-    return f"{bot_name} notes: {summary}. Let's continue talking about {topic}."
+PERSONALITIES = {
+    "neutral": {
+        "rot": 30,
+        "template": "{bot_name} notes: {summary}. Let's continue talking about {topic}."
+    },
+    "excited": {
+        "rot": 15,
+        "template": "{bot_name} exclaims: {summary}! Can't wait to discuss more about {topic}!"
+    },
+}
 
 
-def run_conversation(topic, turns=3):
-    state = ConversationState()
+def bot_response(personality, bot_name, topic, summary):
+    """Return a bot response using the personality template."""
+    template = PERSONALITIES[personality]["template"]
+    return template.format(bot_name=bot_name, topic=topic, summary=summary)
+
+
+def run_conversation(topic, turns=3, personality="neutral"):
+    rot = PERSONALITIES.get(personality, PERSONALITIES["neutral"])['rot']
+    state = ConversationState(rot=rot)
     state.append("user", f"Let's talk about {topic}.")
 
     for _ in range(turns):
         summary = state.get_summary()
-        reply_a = bot_response("Bot A", topic, summary)
+        reply_a = bot_response(personality, "Bot A", topic, summary)
         print(f"Bot A: {reply_a}")
         state.append("assistant", reply_a)
 
         summary = state.get_summary()
-        reply_b = bot_response("Bot B", topic, summary)
+        reply_b = bot_response(personality, "Bot B", topic, summary)
         print(f"Bot B: {reply_b}")
         state.append("assistant", reply_b)
 
@@ -53,6 +68,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Simple conversation with in-memory log and summary")
     parser.add_argument("topic", help="Topic to discuss")
     parser.add_argument("--turns", type=int, default=3, help="Number of exchanges per bot")
+    parser.add_argument("--personality", choices=list(PERSONALITIES.keys()), default="neutral",
+                        help="Personality preset which also controls rot")
     args = parser.parse_args()
 
-    run_conversation(args.topic, args.turns)
+    run_conversation(args.topic, args.turns, args.personality)


### PR DESCRIPTION
## Summary
- keep summary word limit ("rot") configurable via personality presets
- add `--personality` CLI option to `memory_chatbots.py`
- document new personality feature in README

## Testing
- `python -m py_compile chatbots.py memory_chatbots.py main.py`
- `python memory_chatbots.py test_topic --turns 1 --personality excited`
- `python memory_chatbots.py example --turns 1 --personality neutral`


------
https://chatgpt.com/codex/tasks/task_e_685494599cc88333a44e569a8c492d57